### PR TITLE
Fix exception with BenQ w1070 projector

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ BenQ protocol instead. The PJLink protocol is covered by other libraries.
 ## Supported projectors
 
 Known to work:
+* W1070
 * W1100
 * W1110
 * X3000i

--- a/benqprojector/benqprojector.py
+++ b/benqprojector/benqprojector.py
@@ -248,8 +248,9 @@ class BenQProjector:
 
         if self.model:
             try:
+                model_filename = "".join(c if c.isalnum() or c in '._-' else "_" for c in self.model) + ".json"
                 with importlib.resources.open_text(
-                    "benqprojector.configs", f"{self.model}.json"
+                    "benqprojector.configs", model_filename
                 ) as file:
                     self.projector_config = json.load(file)
             except FileNotFoundError:


### PR DESCRIPTION
This projector reports its model as "w1070/w1250", and the forward slash causes an exception trying to load the (non-existant) model config file:

    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/ian/.local/lib/python3.11/site-packages/benqprojector/__main__.py", line 38, in <module>
        if not projector.connect():
               ^^^^^^^^^^^^^^^^^^^
      File "/home/ian/.local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 252, in connect
        with importlib.resources.open_text(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/importlib/resources/_legacy.py", line 25, in wrapper
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/importlib/resources/_legacy.py", line 63, in open_text
        return (_common.files(package) / normalize_path(resource)).open(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/importlib/resources/_legacy.py", line 39, in normalize_path
        raise ValueError(f'{path!r} must be only a file name')
    ValueError: 'w1070/w1250.json' must be only a file name

This replaces the '/' with an underscore when looking for the config file to avoid the exception and allow a config file if one should be needed, though no config file actually seems to be necessary for this particular projector.