### PR TITLE
Fix '_UnixSelectorEventLoop' object has no attribute 'sleep'

### DIFF
--- a/benqprojector/benqprojector.py
+++ b/benqprojector/benqprojector.py
@@ -310,7 +310,7 @@ class BenQProjector:
             #     await asyncio.sleep(seconds)
             # asyncio.run(__sleep())
             # asyncio.run(asyncio.sleep(seconds))
-        except RuntimeError:
+        except (RuntimeError, AttributeError):
             # No running event loop, time.sleep() is safe to use.
             time.sleep(seconds)
 


### PR DESCRIPTION
This exception occurred some time (i.e. initially it worked) after setting up the integration to use a socat link to talk to the projector via an esp-link device, resulting in the projector being marked "unavailable" and not being able to control with home assistant, and the issue persisted across integration reloads and home assistant reboots. It looks like this setup doesn't support asyncio sleep, and the AttributeError exception that was thrown was not the expected fail case. This commit adds that as a second possible exception that will trigger the fallback to use time.sleep().

    Logger: homeassistant.components.media_player
    Source: helpers/update_coordinator.py:258
    Integration: Media player (documentation, issues)
    First occurred: 11:43:16 AM (1 occurrences)
    Last logged: 11:43:16 AM

    Error while setting up benqprojector platform for media_player
    Traceback (most recent call last):
      File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 283, in _async_refresh
	self.data = await self._async_update_data()
		    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/config/custom_components/benqprojector/__init__.py", line 144, in _async_update_data
	if not self.projector.update_power():
	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 758, in update_power
	response = self.send_command("pow")
		   ^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 501, in send_command
	response = self._send_command(command, action)
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 362, in _send_command
	response = self._read_response()
		   ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 448, in _read_response
	self._sleep(0.01)
      File "/usr/local/lib/python3.11/site-packages/benqprojector/benqprojector.py", line 308, in _sleep
	loop.sleep()
	^^^^^^^^^^
    AttributeError: '_UnixSelectorEventLoop' object has no attribute 'sleep'

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 353, in _async_setup_platform
	await asyncio.shield(task)
      File "/config/custom_components/benqprojector/media_player.py", line 33, in async_setup_entry
	await coordinator.async_config_entry_first_refresh()
      File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 258, in async_config_entry_first_refresh
	raise ex
    homeassistant.exceptions.ConfigEntryNotReady: '_UnixSelectorEventLoop' object has no attribute 'sleep'