### PR TITLE
Add support for HT2060

### DIFF
--- a/benqprojector/benqprojector.py
+++ b/benqprojector/benqprojector.py
@@ -241,7 +241,7 @@ class BenQProjector(ABC):
             ) as file:
                 self.projector_config_all = json.load(file)
 
-        if not self.projector_config and self.model:
+        if ( self.projector_config is None ) and self.model:
             try:
                 model_filename = (
                     "".join(c if c.isalnum() or c in "._-" else "_" for c in self.model)
@@ -251,8 +251,12 @@ class BenQProjector(ABC):
                     "benqprojector.configs", model_filename
                 ) as file:
                     self.projector_config = json.load(file)
+                logger.info("Using projector config %s for %s", file.name, model_filename)
             except FileNotFoundError:
-                pass
+                logger.warn("Failed to find specific projector config for %s", model_filename)
+                # Set an empty config so that we do not attempt to reload this file every time.  When commands
+                # are not found in the specific config, we will fall back to the generic 'all' config
+                self.projector_config = {}
 
         if self.projector_config:
             value = self.projector_config.get(key)

--- a/benqprojector/configs/w1140.json
+++ b/benqprojector/configs/w1140.json
@@ -1,0 +1,69 @@
+{
+	"commands": [
+		"3d",
+		"appmod",
+		"asp",
+		"baud",
+		"bgain",
+		"blank",
+		"boffset",
+		"bri",
+		"con",
+		"ct",
+		"directpower",
+		"gamma",
+		"ggain",
+		"goffset",
+		"hdrbri",
+		"highaltitude",
+		"hkeystone",
+		"lampcustom",
+		"lampm",
+		"led",
+		"ltim",
+		"mcufwversion",
+		"menuposition",
+		"modelname",
+		"mute",
+		"pow",
+		"pp",
+		"qas",
+		"rgain",
+		"roffset",
+		"scalerfwversion",
+		"sharp",
+		"sour",
+		"sysfwversion",
+		"tint",
+		"vkeystone",
+		"vol"
+	],
+	"video_sources": [
+		"hdmi",
+		"hdmi2"
+	],
+	"audio_sources": [],
+	"picture_modes": [],
+	"color_temperatures": [],
+	"aspect_ratios": [],
+	"projector_positions": [
+		"ft",
+		"re",
+		"rc",
+		"fc"
+	],
+	"lamp_modes": [
+		"lnor",
+		"eco",
+		"seco"
+	],
+	"3d_modes": [],
+	"menu_positions": [
+		"center",
+		"tl",
+		"tr",
+		"br",
+		"bl"
+	]
+}
+


### PR DESCRIPTION
Adds w1140 configuration for BenQ HT2060 projectors.  w1140.json was sourced from the 'examine' command and is unchanged.
``
Model: w1140
Supported commands: 3d? appmod? asp? baud bgain? blank boffset? bri? con? ct? directpower gamma? ggain? goffset? hdrbri? highaltitude hkeystone? lampcustom lampm led ltim mcufwversion menuposition modelname mute? pow pp qas rgain? roffset? scalerfwversion sharp? sour sysfwversion tint? vkeystone? vol?
Supported video sources: hdmi hdmi2
Supported picture modes:Supported color temperatures:Supported aspect ratios:Supported projector positions: ft re rc fc
Supported lamp modes: lnor eco seco
Supported 3d modes:Supported menu positions: center tl tr br bl
Projector configuration JSON:
{
	"commands": [
		"3d",
		"appmod",
		"asp",
		"baud",
		"bgain",
		"blank",
		"boffset",
		"bri",
		"con",
		"ct",
		"directpower",
		"gamma",
		"ggain",
		"goffset",
		"hdrbri",
		"highaltitude",
		"hkeystone",
		"lampcustom",
		"lampm",
		"led",
		"ltim",
		"mcufwversion",
		"menuposition",
		"modelname",
		"mute",
		"pow",
		"pp",
		"qas",
		"rgain",
		"roffset",
		"scalerfwversion",
		"sharp",
		"sour",
		"sysfwversion",
		"tint",
		"vkeystone",
		"vol"
	],
	"video_sources": [
		"hdmi",
		"hdmi2"
	],
	"audio_sources": [],
	"picture_modes": [],
	"color_temperatures": [],
	"aspect_ratios": [],
	"projector_positions": [
		"ft",
		"re",
		"rc",
		"fc"
	],
	"lamp_modes": [
		"lnor",
		"eco",
		"seco"
	],
	"3d_modes": [],
	"menu_positions": [
		"center",
		"tl",
		"tr",
		"br",
		"bl"
	]
}
``

Additionally, add logging showing which configuration is being used at runtime (happy if this gets left out, but I thought it was useful).