### PR TITLE
Add w1140 configuration for BenQ HT2060

### DIFF
--- a/benqprojector/configs/w1140.json
+++ b/benqprojector/configs/w1140.json
@@ -1,0 +1,69 @@
+{
+	"commands": [
+		"3d",
+		"appmod",
+		"asp",
+		"baud",
+		"bgain",
+		"blank",
+		"boffset",
+		"bri",
+		"con",
+		"ct",
+		"directpower",
+		"gamma",
+		"ggain",
+		"goffset",
+		"hdrbri",
+		"highaltitude",
+		"hkeystone",
+		"lampcustom",
+		"lampm",
+		"led",
+		"ltim",
+		"mcufwversion",
+		"menuposition",
+		"modelname",
+		"mute",
+		"pow",
+		"pp",
+		"qas",
+		"rgain",
+		"roffset",
+		"scalerfwversion",
+		"sharp",
+		"sour",
+		"sysfwversion",
+		"tint",
+		"vkeystone",
+		"vol"
+	],
+	"video_sources": [
+		"hdmi",
+		"hdmi2"
+	],
+	"audio_sources": [],
+	"picture_modes": [],
+	"color_temperatures": [],
+	"aspect_ratios": [],
+	"projector_positions": [
+		"ft",
+		"re",
+		"rc",
+		"fc"
+	],
+	"lamp_modes": [
+		"lnor",
+		"eco",
+		"seco"
+	],
+	"3d_modes": [],
+	"menu_positions": [
+		"center",
+		"tl",
+		"tr",
+		"br",
+		"bl"
+	]
+}
+


### PR DESCRIPTION
Note that this configuration has only been minimally tested, but 'seems to work'(TM).  It was created directly from the output of the 'examine' command:

Model: w1140 Supported commands: 3d? appmod? asp? baud bgain? blank boffset? bri? con? ct? directpower gamma? ggain? goffset? hdrbri? highaltitude hkeystone? lampcustom lampm led ltim mcufwversion menuposition modelname mute? pow pp qas rgain? roffset? scalerfwversion sharp? sour sysfwversion tint? vkeystone? vol? 
Supported video sources: hdmi hdmi2 
Supported picture modes:
Supported color temperatures:
Supported aspect ratios:
Supported projector positions: ft re rc fc 
Supported lamp modes: lnor eco seco 
Supported 3d modes:
Supported menu positions: center tl tr br bl 

Projector configuration JSON: { "commands": [ "3d", "appmod", "asp", "baud", "bgain", "blank", "boffset", "bri", "con", "ct", "directpower", "gamma", "ggain", "goffset", "hdrbri", "highaltitude", "hkeystone", "lampcustom", "lampm", "led", "ltim", "mcufwversion", "menuposition", "modelname", "mute", "pow", "pp", "qas", "rgain", "roffset", "scalerfwversion", "sharp", "sour", "sysfwversion", "tint", "vkeystone", "vol" ], "video_sources": [ "hdmi", "hdmi2" ], "audio_sources": [], "picture_modes": [], "color_temperatures": [], "aspect_ratios": [], "projector_positions": [ "ft", "re", "rc", "fc" ], "lamp_modes": [ "lnor", "eco", "seco" ], "3d_modes": [], "menu_positions": [ "center", "tl", "tr", "br", "bl" ] }