### PR TITLE
Fix: Reduce \r flooding and increase Telnet timeout for TCP/serial bridges

### DIFF
--- a/benqprojector/__init__.py
+++ b/benqprojector/__init__.py
@@ -189,7 +189,7 @@ class BenQProjector(ABC):
 
         try:
             if text is not None and len(text) > 0:
-                return json.load(text)
+                return json.loads(text)
 
             logger.debug("No or empty read config file %s", model_filename)
         except JSONDecodeError:

--- a/benqprojector/__init__.py
+++ b/benqprojector/__init__.py
@@ -584,7 +584,7 @@ class BenQProjector(ABC):
             if (datetime.now() - start_time).total_seconds() > 1:
                 raise BenQPromptTimeoutError()
 
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1)
 
         logger.warning("Prompt not detected")
         return False

--- a/benqprojector/benqconnection.py
+++ b/benqprojector/benqconnection.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Timeout in seconds
 _SERIAL_TIMEOUT = 0.05
-_TELNET_TIMEOUT = 0.2
+_TELNET_TIMEOUT = 1.0
 
 DEFAULT_PORT = 8000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ Homepage = "https://github.com/rrooggiieerr/benqprojector.py"
 Issues = "https://github.com/rrooggiieerr/benqprojector.py/issues"
 [tool.isort]
 profile = "black"
-[tool.black]
 [tool.pylint]
 recursive = "y"
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.24", "hatch-vcs"]
+requires = ["hatchling>=1.24"]
 build-backend = "hatchling.build"
-
-[tool.hatch.build.hooks.vcs]
-version-file = "benqprojector/_version.py"
-
-[tool.hatch.version]
-source = "vcs"
 
 [project]
 name = "benqprojector"
-dynamic = ["version"]
+version = "0.1.9.1"
 license = {text = "Apache-2.0"}
 authors = [
     { name="Rogier van Staveren", email="rogier@batoid.com" }
@@ -34,27 +28,17 @@ dependencies = [
     "pyserial-asyncio-fast>=0.16",
     "aiofiles>=25.1.0",
 ]
-
 [project.urls]
 Homepage = "https://github.com/rrooggiieerr/benqprojector.py"
 Issues = "https://github.com/rrooggiieerr/benqprojector.py/issues"
-
 [tool.isort]
-# https://github.com/PyCQA/isort/wiki/isort-Settings
 profile = "black"
-skip = "benqprojector/_version.py"
-
 [tool.black]
-exclude = "benqprojector/_version.py"
-
 [tool.pylint]
-ignore = "_version.py"
 recursive = "y"
-
 [tool.mypy]
 python_version = "3.11"
 mypy_path = "benqprojector"
-
 [[tool.mypy.overrides]]
 module = ["serial.*", "*._version"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [build-system]
 requires = ["hatchling>=1.24", "hatch-vcs"]
 build-backend = "hatchling.build"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "benqprojector/_version.py"
+
 [tool.hatch.version]
 source = "vcs"
+
 [project]
 name = "benqprojector"
 dynamic = ["version"]
@@ -31,21 +34,27 @@ dependencies = [
     "pyserial-asyncio-fast>=0.16",
     "aiofiles>=25.1.0",
 ]
+
 [project.urls]
 Homepage = "https://github.com/rrooggiieerr/benqprojector.py"
 Issues = "https://github.com/rrooggiieerr/benqprojector.py/issues"
+
 [tool.isort]
 # https://github.com/PyCQA/isort/wiki/isort-Settings
 profile = "black"
 skip = "benqprojector/_version.py"
+
 [tool.black]
 exclude = "benqprojector/_version.py"
+
 [tool.pylint]
 ignore = "_version.py"
 recursive = "y"
+
 [tool.mypy]
 python_version = "3.11"
 mypy_path = "benqprojector"
+
 [[tool.mypy.overrides]]
 module = ["serial.*", "*._version"]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,13 @@
 [build-system]
-requires = ["hatchling>=1.24"]
+requires = ["hatchling>=1.24", "hatch-vcs"]
 build-backend = "hatchling.build"
-
+[tool.hatch.build.hooks.vcs]
+version-file = "benqprojector/_version.py"
+[tool.hatch.version]
+source = "vcs"
 [project]
 name = "benqprojector"
-version = "0.1.9.1"
+dynamic = ["version"]
 license = {text = "Apache-2.0"}
 authors = [
     { name="Rogier van Staveren", email="rogier@batoid.com" }
@@ -32,8 +35,13 @@ dependencies = [
 Homepage = "https://github.com/rrooggiieerr/benqprojector.py"
 Issues = "https://github.com/rrooggiieerr/benqprojector.py/issues"
 [tool.isort]
+# https://github.com/PyCQA/isort/wiki/isort-Settings
 profile = "black"
+skip = "benqprojector/_version.py"
+[tool.black]
+exclude = "benqprojector/_version.py"
 [tool.pylint]
+ignore = "_version.py"
 recursive = "y"
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Fix: \r flooding, Telnet timeout and json.loads bug for TCP/serial bridges

This PR fixes three issues that together make the integration unusable when using a serial-to-TCP bridge (e.g. ESP32 with esphome-stream-server).

---

### Fix 1: Reduce \r flooding in `_wait_for_prompt()`

**File:** `benqprojector/__init__.py`

When the projector stops issuing the `>` prompt during boot, `_wait_for_prompt()` sends `\r` every **50ms** (up to 20 times per second). This floods the UART buffer on TCP bridges and prevents the projector from ever recovering after boot.

**Fix:** Increased `asyncio.sleep(0.05)` to `asyncio.sleep(1.0)` — reduces polling from ~20/second to max 1/second.

---

### Fix 2: Increase Telnet timeout in `benqconnection.py`

**File:** `benqprojector/benqconnection.py`

`_TELNET_TIMEOUT = 0.2` (200ms) is too short for WiFi-based TCP bridges where latency can be 50–100ms, causing responses to be missed.

**Fix:** Increased `_TELNET_TIMEOUT` from `0.2` to `1.0` seconds.

---

### Fix 3: `json.load()` should be `json.loads()` in `_read_config()`

**File:** `benqprojector/__init__.py`

`importlib.resources.read_text()` returns a **string**, not a file object. `json.load()` expects a file object and raises:
```
AttributeError: 'str' object has no attribute 'read'
```

**Fix:** Changed `json.load(text)` to `json.loads(text)`.

---

### Tested with
- BenQ W4100i
- ESP32 with esphome-stream-server as RS232-to-TCP bridge
- 9600 baud, port 8000
- Home Assistant OS 17.1 / Core 2026.3.4

### Additional observation
When turning the projector OFF with the physical remote during the `\r` flood, the integration correctly received `*POW=OFF#` — confirming the RS232 connection itself still works. The issue is purely the `\r` flood preventing the projector from issuing a new `>` prompt after booting.