### PR TITLE
Migrate to serialx for serial connections

### DIFF
--- a/benqprojector/__init__.py
+++ b/benqprojector/__init__.py
@@ -189,7 +189,7 @@ class BenQProjector(ABC):
 
         try:
             if text is not None and len(text) > 0:
-                return json.load(text)
+                return json.loads(text)
 
             logger.debug("No or empty read config file %s", model_filename)
         except JSONDecodeError:

--- a/benqprojector/__main__.py
+++ b/benqprojector/__main__.py
@@ -11,7 +11,7 @@ import logging
 import sys
 from typing import Any
 
-from serial.serialutil import SerialException
+from serialx import SerialException
 
 from benqprojector import (
     DEFAULT_PORT,

--- a/benqprojector/benqconnection.py
+++ b/benqprojector/benqconnection.py
@@ -13,8 +13,7 @@ import time
 from abc import ABC, abstractmethod
 
 import aiofiles
-import serial
-import serial_asyncio_fast as serial_asyncio
+import serialx
 
 logger = logging.getLogger(__name__)
 
@@ -255,17 +254,16 @@ class BenQSerialConnection(BenQConnection):
                 (
                     self._reader,
                     self._writer,
-                ) = await serial_asyncio.open_serial_connection(
+                ) = await serialx.open_serial_connection(
                     url=self._serial_port,
                     baudrate=self._baud_rate,
-                    bytesize=serial.EIGHTBITS,
-                    parity=serial.PARITY_NONE,
-                    stopbits=serial.STOPBITS_ONE,
-                    timeout=_SERIAL_TIMEOUT,
+                    byte_size=serialx.EIGHTBITS,
+                    parity=serialx.Parity.NONE,
+                    stopbits=serialx.StopBits.ONE,
                 )
 
             return True
-        except serial.SerialException as ex:
+        except (OSError, TimeoutError, ValueError, serialx.SerialException) as ex:
             raise BenQConnectionError(str(ex)) from ex
 
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ classifiers = [
     "Topic :: Home Automation"
 ]
 dependencies = [
-    "pyserial>=3.5",
-    "pyserial-asyncio-fast>=0.16",
+    "serialx>=1.7.2",
     "aiofiles>=25.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiofiles==25.1.0
-pyserial==3.5
-pyserial-asyncio-fast==0.16
+serialx==1.7.2

--- a/tests/testBenQSerialConnectionMock.py
+++ b/tests/testBenQSerialConnectionMock.py
@@ -1,0 +1,44 @@
+# pylint: disable=invalid-name
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+import serialx
+
+from benqprojector.benqconnection import BenQSerialConnection
+
+BAUD_RATE = 115200
+
+
+class Test(unittest.IsolatedAsyncioTestCase):
+    async def _test_open(self, serial_port: str):
+        connection = BenQSerialConnection(serial_port, BAUD_RATE)
+        reader = Mock()
+        writer = Mock()
+        writer.close = Mock()
+        writer.wait_closed = AsyncMock()
+
+        with patch(
+            "benqprojector.benqconnection.serialx.open_serial_connection",
+            AsyncMock(return_value=(reader, writer)),
+        ) as open_serial_connection:
+            result = await connection.open()
+
+        self.assertTrue(result)
+        self.assertTrue(connection.is_open())
+        open_serial_connection.assert_awaited_once_with(
+            url=serial_port,
+            baudrate=BAUD_RATE,
+            byte_size=serialx.EIGHTBITS,
+            parity=serialx.Parity.NONE,
+            stopbits=serialx.StopBits.ONE,
+        )
+
+        await connection.close()
+
+    async def test_open_uses_serial_path(self):
+        await self._test_open("/dev/tty.usbserial-10")
+
+    async def test_open_uses_serial_uri(self):
+        await self._test_open("esphome-hass://esphome/abc123?port_name=uart0")


### PR DESCRIPTION
## Summary

1. This migrates the serial connection layer from `pyserial-asyncio-fast` to `serialx`. The caller-facing serial API remains the same. Existing users still pass the same serial port string and baud rate. Telnet/network connections are not changed.
2. I also ran into a config parsing issue in `__init__.py` of main branch: the code used `json.load()` to try to parse a string. This PR corrects that to `json.loads()`.

## Reason

Home Assistant 2026.5 introduced ESPHome serial proxy support and migrated its serial handling to `serialx`. The release notes also suggested custom integrations and libraries that still use `pyserial`, `pyserial-asyncio`, or `pyserial-asyncio-fast` migrate to `serialx` and use the new serial port picker.

This is library behind the BenQ Projector integration, so replacing the serial layer here is needed before the integration can support Home Assistant serial proxy URIs such as `esphome-hass://...`. I've got the integration changes prepared as well. On the integration side, the only thing changed is the picker in the serial path of config flow while the network path remains unchanged. Once this PR is merged and released, I can open the integration PR.

Relevant articles:

- [Home Assistant 2026.5 release notes, “Serial ports over the network with ESPHome”](https://www.home-assistant.io/blog/2026/05/06/release-20265/#serial-ports-over-the-network-with-esphome)
- [ESPHome `serial_proxy` documentation](https://esphome.io/components/serial_proxy/)

## Changes

- Replace `pyserial-asyncio-fast` / `pyserial` serial opening with `serialx.open_serial_connection`
- Allow serial URI values to be passed through as serial URLs
- Add tests covering regular serial paths and `esphome-hass://...` URI paths
- Fix config JSON parsing from package resources by using `json.loads()`

## Validation

I tested the branch locally with both the existing network serial bridge path and an ESPHome serial proxy setup. I don't have a rs232 dongle nearby however so please also test it with hardwired connections.

A small test was added for the serial connection layer to make sure both a normal local serial device path and an `esphome-hass://...` serial proxy URI are passed through to `serialx.open_serial_connection()` unchanged.