### PR TITLE
Migrate to serialx for network connections

### DIFF
--- a/benqprojector/benqconnection.py
+++ b/benqprojector/benqconnection.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 # Timeout in seconds
 _SERIAL_TIMEOUT = 0.05
 _TELNET_TIMEOUT = 0.2
+_CONNECT_TIMEOUT = 10
+
+# Required by serialx but ignored by the socket transport.
+_SOCKET_BAUD_RATE = 9600
 
 DEFAULT_PORT = 8000
 
@@ -283,6 +287,8 @@ class BenQTelnetConnection(BenQConnection):
 
         self._host = host
         self._port = port
+        uri_host = host if ":" not in host or host.startswith("[") else f"[{host}]"
+        self._url = f"socket://{uri_host}:{port}"
 
     def __str__(self):
         return f"{self._host}:{self._port}"
@@ -292,15 +298,19 @@ class BenQTelnetConnection(BenQConnection):
 
         try:
             if not self.is_open():
-                self._reader, self._writer = await asyncio.wait_for(
-                    asyncio.open_connection(self._host, self._port), timeout=10
+                self._reader, self._writer = await serialx.open_serial_connection(
+                    url=self._url,
+                    baudrate=_SOCKET_BAUD_RATE,
+                    connect_timeout=_CONNECT_TIMEOUT,
                 )
 
             return True
-        except asyncio.exceptions.TimeoutError as ex:
+        except TimeoutError as ex:
             raise BenQConnectionTimeoutError(str(ex)) from ex
         except socket.gaierror as ex:
             raise BenQConnectionError(ex.strerror) from ex
+        except (ValueError, serialx.SerialException) as ex:
+            raise BenQConnectionError(str(ex)) from ex
         except OSError as ex:
             if ex.errno in [64, 113]:
                 await self.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Home Automation"
 ]
 dependencies = [
-    "serialx>=1.7.2",
+    "serialx>=1.8.2",
     "aiofiles>=25.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiofiles==25.1.0
-serialx==1.7.2
+serialx==1.8.2

--- a/tests/testBenQTelnetConnectionMock.py
+++ b/tests/testBenQTelnetConnectionMock.py
@@ -1,0 +1,72 @@
+# pylint: disable=invalid-name
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from benqprojector.benqconnection import (
+    BenQConnectionTimeoutError,
+    BenQTelnetConnection,
+)
+
+HOST = "benqprojector-livingroom.local"
+PORT = 8000
+
+
+class Test(unittest.IsolatedAsyncioTestCase):
+    async def _test_open(self, host: str, expected_url: str):
+        connection = BenQTelnetConnection(host, PORT)
+        reader = Mock()
+        writer = Mock()
+        writer.close = Mock()
+        writer.wait_closed = AsyncMock()
+
+        with patch(
+            "benqprojector.benqconnection.serialx.open_serial_connection",
+            AsyncMock(return_value=(reader, writer)),
+        ) as open_serial_connection:
+            result = await connection.open()
+
+        self.assertTrue(result)
+        self.assertTrue(connection.is_open())
+        open_serial_connection.assert_awaited_once_with(
+            url=expected_url,
+            baudrate=9600,
+            connect_timeout=10,
+        )
+
+        await connection.close()
+
+    async def test_open_uses_socket_url(self):
+        await self._test_open(HOST, f"socket://{HOST}:{PORT}")
+
+    async def test_open_uses_ipv6_socket_url(self):
+        await self._test_open("2001:db8::1", f"socket://[2001:db8::1]:{PORT}")
+
+    async def test_open_timeout(self):
+        connection = BenQTelnetConnection(HOST, PORT)
+
+        with (
+            patch(
+                "benqprojector.benqconnection.serialx.open_serial_connection",
+                AsyncMock(side_effect=TimeoutError),
+            ),
+            self.assertRaises(BenQConnectionTimeoutError),
+        ):
+            await connection.open()
+
+    async def test_open_returns_false_on_connection_error(self):
+        connection = BenQTelnetConnection(HOST, PORT)
+
+        with (
+            patch(
+                "benqprojector.benqconnection.serialx.open_serial_connection",
+                AsyncMock(
+                    side_effect=ConnectionRefusedError(111, "Connection refused")
+                ),
+            ),
+            patch("benqprojector.benqconnection.logger.exception") as log_exception,
+        ):
+            self.assertFalse(await connection.open())
+
+        log_exception.assert_called_once_with("Unhandled OSError")


### PR DESCRIPTION
Updates the `BenQProjectorTelnet` path to use `serialx`, with tests for socket URL handling, IPv6, timeouts, and connection errors.

Also bumps serialx to 1.8.2 for its socket transport lifecycle and connection handling fixes.

This should complete the migration.