### PR TITLE
Recover serial connections after transport errors

### DIFF
--- a/benqprojector/__init__.py
+++ b/benqprojector/__init__.py
@@ -755,6 +755,10 @@ class BenQProjector(ABC):
             )
         except BenQConnectionError:
             await self.connection.close()
+        except BenQResponseTimeoutError:
+            # A transport can retain a non-closing writer after the underlying
+            # connection is lost. Force a fresh connection on the next poll.
+            await self.connection.close()
         except BenQProjectorError:
             pass
 

--- a/benqprojector/benqconnection.py
+++ b/benqprojector/benqconnection.py
@@ -90,6 +90,10 @@ class BenQConnection(ABC):
             await self._writer.wait_closed()
         except (OSError, serialx.SerialException):
             pass
+        # Some transports leak implementation-specific exceptions while their
+        # underlying connection is being closed. The local state must still be reset.
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Transport error while closing connection")
 
         self._reader = None
         self._writer = None
@@ -105,9 +109,13 @@ class BenQConnection(ABC):
         """
         Resets the reader and drains the writer of the connection.
         """
-        await self.read(-1)
-        await self._writer.drain()
-        return True
+        try:
+            await self.read(-1)
+            await self._writer.drain()
+            return True
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            await self.close()
+            raise BenQConnectionError(str(ex)) from ex
 
     async def read(self, size: int = 1) -> bytes:
         """
@@ -129,7 +137,11 @@ class BenQConnection(ABC):
             return b""
         except (OSError, serialx.SerialException) as ex:
             await self.close()
-            raise BenQConnectionError(ex.strerror) from ex
+            raise BenQConnectionError(str(ex)) from ex
+        # serialx transports may leak backend-specific exceptions.
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            await self.close()
+            raise BenQConnectionError(str(ex)) from ex
 
         return b""
 
@@ -153,7 +165,10 @@ class BenQConnection(ABC):
             return b""
         except (OSError, serialx.SerialException) as ex:
             await self.close()
-            raise BenQConnectionError(ex.strerror) from ex
+            raise BenQConnectionError(str(ex)) from ex
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            await self.close()
+            raise BenQConnectionError(str(ex)) from ex
 
         return b""
 
@@ -182,7 +197,10 @@ class BenQConnection(ABC):
             return b""
         except (OSError, serialx.SerialException) as ex:
             await self.close()
-            raise BenQConnectionError(ex.strerror) from ex
+            raise BenQConnectionError(str(ex)) from ex
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            await self.close()
+            raise BenQConnectionError(str(ex)) from ex
 
         return b""
 
@@ -197,7 +215,10 @@ class BenQConnection(ABC):
             return len(data)
         except (OSError, serialx.SerialException) as ex:
             await self.close()
-            raise BenQConnectionError(ex.strerror) from ex
+            raise BenQConnectionError(str(ex)) from ex
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            await self.close()
+            raise BenQConnectionError(str(ex)) from ex
 
     async def flush(self) -> None:
         """

--- a/benqprojector/benqconnection.py
+++ b/benqprojector/benqconnection.py
@@ -67,7 +67,12 @@ class BenQConnection(ABC):
         """
         Checks if the connection is open.
         """
-        return self._writer is not None
+        return (
+            self._writer is not None
+            and self._reader is not None
+            and not self._writer.is_closing()
+            and not self._reader.at_eof()
+        )
 
     async def close(self) -> bool:
         """
@@ -76,7 +81,8 @@ class BenQConnection(ABC):
         if self._record_file:
             await self._record_file.close()
 
-        if not self.is_open():
+        if self._writer is None:
+            self._reader = None
             return True
 
         try:
@@ -221,6 +227,8 @@ class BenQSerialConnection(BenQConnection):
         await super().open()
 
         try:
+            if self._writer is not None and not self.is_open():
+                await self.close()
             if not self.is_open():
                 (
                     self._reader,

--- a/tests/testBenQSerialConnectionMock.py
+++ b/tests/testBenQSerialConnectionMock.py
@@ -15,8 +15,10 @@ class Test(unittest.IsolatedAsyncioTestCase):
     async def _test_open(self, serial_port: str):
         connection = BenQSerialConnection(serial_port, BAUD_RATE)
         reader = Mock()
+        reader.at_eof.return_value = False
         writer = Mock()
         writer.close = Mock()
+        writer.is_closing.return_value = False
         writer.wait_closed = AsyncMock()
 
         with patch(
@@ -33,6 +35,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
             byte_size=serialx.EIGHTBITS,
             parity=serialx.Parity.NONE,
             stopbits=serialx.StopBits.ONE,
+            timeout=1,
         )
 
         await connection.close()
@@ -42,3 +45,30 @@ class Test(unittest.IsolatedAsyncioTestCase):
 
     async def test_open_uses_serial_uri(self):
         await self._test_open("esphome-hass://esphome/abc123?port_name=uart0")
+
+    async def test_closed_transport_is_replaced(self):
+        connection = BenQSerialConnection("/dev/tty.old", BAUD_RATE)
+        old_reader = Mock()
+        old_reader.at_eof.return_value = True
+        old_writer = Mock()
+        old_writer.close = Mock()
+        old_writer.is_closing.return_value = False
+        old_writer.wait_closed = AsyncMock()
+        connection._reader = old_reader
+        connection._writer = old_writer
+
+        new_reader = Mock()
+        new_reader.at_eof.return_value = False
+        new_writer = Mock()
+        new_writer.is_closing.return_value = False
+
+        with patch(
+            "benqprojector.benqconnection.serialx.open_serial_connection",
+            AsyncMock(return_value=(new_reader, new_writer)),
+        ):
+            self.assertTrue(await connection.open())
+
+        old_writer.close.assert_called_once_with()
+        old_writer.wait_closed.assert_awaited_once_with()
+        self.assertIs(connection._reader, new_reader)
+        self.assertIs(connection._writer, new_writer)

--- a/tests/testBenQSerialConnectionMock.py
+++ b/tests/testBenQSerialConnectionMock.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import serialx
 
-from benqprojector.benqconnection import BenQSerialConnection
+from benqprojector import BenQProjectorSerial
+from benqprojector.benqclasses import BenQResponseTimeoutError
+from benqprojector.benqconnection import BenQConnectionError, BenQSerialConnection
 
 BAUD_RATE = 115200
 
@@ -72,3 +74,26 @@ class Test(unittest.IsolatedAsyncioTestCase):
         old_writer.wait_closed.assert_awaited_once_with()
         self.assertIs(connection._reader, new_reader)
         self.assertIs(connection._writer, new_writer)
+
+    async def test_backend_write_error_closes_connection(self):
+        connection = BenQSerialConnection("esphome://device", BAUD_RATE)
+        connection._reader = Mock()
+        connection._reader.at_eof.return_value = False
+        connection._writer = Mock()
+        connection._writer.is_closing.return_value = False
+        connection._writer.drain = AsyncMock(side_effect=RuntimeError("API stopped"))
+        connection._writer.wait_closed = AsyncMock()
+
+        with self.assertRaisesRegex(BenQConnectionError, "API stopped"):
+            await connection.write(b"test")
+
+        self.assertFalse(connection.is_open())
+
+    async def test_response_timeout_closes_connection(self):
+        projector = BenQProjectorSerial("esphome://device", BAUD_RATE)
+        projector._send_command = AsyncMock(side_effect=BenQResponseTimeoutError())
+        projector.connection.close = AsyncMock()
+
+        self.assertIsNone(await projector.send_command("pow"))
+
+        projector.connection.close.assert_awaited_once_with()


### PR DESCRIPTION
I ran into an issue where a projector connected through a network serial proxy stayed unavailable after a transport timeout instead of reconnecting on the next update.

The reader and writer could remain set after the underlying transport had closed, so the connection was still treated as open. This change detects closed streams and clears stale connection state after transport or response errors, allowing the next poll to reconnect.

Tested with an ESPHome serial proxy and covered by the serial connection mock tests.
